### PR TITLE
fix: Immediately Re-enable delegations and staking on Luna Classic.  Re-enable the creation of new validators at block height 8905758

### DIFF
--- a/x/staking/keeper/msg_server.go
+++ b/x/staking/keeper/msg_server.go
@@ -17,22 +17,22 @@ import (
 // StakingPowerUpgradeHeight defines the block height after which messages that
 // would impact staking power are no longer supported.
 const StakingPowerUpgradeHeight = 7603700
-//StakingPowerRevertHeight re-enables the creation of validators after this 
-//block height.  This has been computed as approximately August 22, 2022.  68 days from June 15
-//With an average of 7 second blocks, there are approximately 8.571 blocks per minute (60/7)
-//8.571 * 60 min * 24 hrs * 68 days = 839,272 blocks
-//current block height on June 15 is 8,066,486
-//projected block on August 22 is 8,066,486 + 839,272 = 8,905,758
+// StakingPowerRevertHeight re-enables the creation of validators after this 
+// block height.  This has been computed as approximately August 22, 2022.  68 days from June 15
+// With an average of 7 second blocks, there are approximately 8.571 blocks per minute (60/7)
+// 8.571 * 60 min * 24 hrs * 68 days = 839,272 blocks
+// current block height on June 15 is 8,066,486
+// projected block on August 22 is 8,066,486 + 839,272 = 8,905,758
 const StakingPowerRevertHeight = 8905758
 
-//DelegatePowerRevertHeight re-enables the ability to delegate stake to existing validators
-//This is an approximate block height of adoption.  The exact block height can be agreed upon
-//if governance 4095 passes and validators agree to adopt the code patch.
-//projected block 5 days from now, June 20 is 
-//8.571 * 60min * 24 hrs * 5 days = 61,711 blocks
-//current block height on June 20 is 8,146,938
-//projected block on June 25 is 8,146,938 + 61,711 = 8,208,649. 
-//This is approximate and will be adjusted if needed
+// DelegatePowerRevertHeight re-enables the ability to delegate stake to existing validators
+// This is an approximate block height of adoption.  The exact block height can be agreed upon
+// if governance 4095 passes and validators agree to adopt the code patch.
+// projected block 5 days from now, June 20 is 
+// 8.571 * 60min * 24 hrs * 5 days = 61,711 blocks
+// current block height on June 20 is 8,146,938
+// projected block on June 25 is 8,146,938 + 61,711 = 8,208,649. 
+// This is approximate and will be adjusted if needed
 const DelegatePowerRevertHeight = 8208649
 
 type msgServer struct {

--- a/x/staking/keeper/msg_server.go
+++ b/x/staking/keeper/msg_server.go
@@ -18,12 +18,12 @@ import (
 // would impact staking power are no longer supported.
 const StakingPowerUpgradeHeight = 7603700
 //StaingPowerReverseHeight re-enables the creation of validators after this 
-//block height.  This has been computed as approximately July 30, 2022.  45 days from June 14
+//block height.  This has been computed as approximately August 22, 2022.  68 days from June 15
 //With an average of 7 second blocks, there are approximately 8.571 blocks per minute (60/7)
-//8.571 * 60 min * 24 hrs * 45 days = 555,428 blocks
-//current block height on June 14 is 8,066,486
-//projected block on July 30 is 8,066,486 + 555,428 = 8,621,914
-const StakingPowerReverseHeight = 8621914
+//8.571 * 60 min * 24 hrs * 68 days = 839,272 blocks
+//current block height on June 15 is 8,066,486
+//projected block on August 22 is 8,066,486 + 839,272 = 8,905,758
+const StakingPowerReverseHeight = 8905758
 
 type msgServer struct {
 	Keeper

--- a/x/staking/keeper/msg_server.go
+++ b/x/staking/keeper/msg_server.go
@@ -23,7 +23,8 @@ const StakingPowerUpgradeHeight = 7603700
 // 8.571 * 60 min * 24 hrs * 68 days = 839,272 blocks
 // current block height on June 15 is 8,066,486
 // projected block on August 22 is 8,066,486 + 839,272 = 8,905,758
-const StakingPowerRevertHeight = 8905758
+//const StakingPowerRevertHeight = 8905758
+const StakingPowerRevertHeight = 7714490
 
 // DelegatePowerRevertHeight re-enables the ability to delegate stake to existing validators
 // This is an approximate block height of adoption.  The exact block height can be agreed upon
@@ -33,7 +34,12 @@ const StakingPowerRevertHeight = 8905758
 // current block height on June 20 is 8,146,938
 // projected block on June 25 is 8,146,938 + 61,711 = 8,208,649. 
 // This is approximate and will be adjusted if needed
-const DelegatePowerRevertHeight = 8208649
+//const DelegatePowerRevertHeight = 8208649
+const DelegatePowerRevertHeight = 7684490
+
+// ProtectPowerHeight protects the blockchain from BFT attack during the upgrade
+// This prevents any one validator from obtaining more than 25% of the staking power
+const ProtectPowerHeight = 7704490
 
 type msgServer struct {
 	Keeper
@@ -241,6 +247,32 @@ func (k msgServer) Delegate(goCtx context.Context, msg *types.MsgDelegate) (*typ
 			sdkerrors.ErrInvalidRequest, "invalid coin denomination: got %s, expected %s", msg.Amount.Denom, bondDenom,
 		)
 	}
+
+	// If Delegations are allowed, but we are in a vulnerable state below ProtectPowerHeight, limit validator power
+        if currHeight >= DelegatePowerRevertHeight && currHeight < ProtectPowerHeight {
+	        // Get the Total Consensus Power of all Validators
+	        lastPower := k.Keeper.GetLastTotalPower(ctx)
+	        ctx.Logger().Info(fmt.Sprintf("lastPower is %s", lastPower))
+
+	        // Get the selected Validator's voting power
+	        validatorLastPower := k.Keeper.GetLastValidatorPower(ctx, valAddr)
+	        ctx.Logger().Info(fmt.Sprintf("lastPower of Validator is %d", validatorLastPower))
+
+	        // Compute what the Validator's new power would be if this Delegation goes through
+	        validatorNewPower := int64(validatorLastPower) + sdk.TokensToConsensusPower(msg.Amount.Amount, k.Keeper.PowerReduction(ctx))
+
+	        // Compute what the Total Consensus Power would be if this Delegation goes through
+	        newTotalPower := lastPower.Int64() + sdk.TokensToConsensusPower(msg.Amount.Amount, k.Keeper.PowerReduction(ctx))
+	        ctx.Logger().Info(fmt.Sprintf("newPower of Validator would be %d", validatorNewPower))
+
+	        // Compute what the new Validator voting power would be in relation to the new total power
+	        validatorIncreasedDelegationPercent := float32(validatorNewPower) / float32(newTotalPower)
+
+		// If Delegations are allowed, and the Delegation would have increased the Validator to over 25% of the staking power, do not allow the Delegation to proceed
+                if validatorIncreasedDelegationPercent > 0.25 {
+                        return nil, sdkerrors.Wrapf(types.ErrMsgNotSupported, "message type %T is over the allowed limit at height %d", msg, currHeight)
+                }
+        }
 
 	// NOTE: source funds are always unbonded
 	newShares, err := k.Keeper.Delegate(ctx, delegatorAddress, msg.Amount.Amount, types.Unbonded, validator, true)

--- a/x/staking/keeper/msg_server.go
+++ b/x/staking/keeper/msg_server.go
@@ -17,13 +17,23 @@ import (
 // StakingPowerUpgradeHeight defines the block height after which messages that
 // would impact staking power are no longer supported.
 const StakingPowerUpgradeHeight = 7603700
-//StaingPowerReverseHeight re-enables the creation of validators after this 
+//StakingPowerRevertHeight re-enables the creation of validators after this 
 //block height.  This has been computed as approximately August 22, 2022.  68 days from June 15
 //With an average of 7 second blocks, there are approximately 8.571 blocks per minute (60/7)
 //8.571 * 60 min * 24 hrs * 68 days = 839,272 blocks
 //current block height on June 15 is 8,066,486
 //projected block on August 22 is 8,066,486 + 839,272 = 8,905,758
-const StakingPowerReverseHeight = 8905758
+const StakingPowerRevertHeight = 8905758
+
+//DelegatePowerRevertHeight re-enables the ability to delegate stake to existing validators
+//This is an approximate block height of adoption.  The exact block height can be agreed upon
+//if governance 4095 passes and validators agree to adopt the code patch.
+//projected block 5 days from now, June 20 is 
+//8.571 * 60min * 24 hrs * 5 days = 61,711 blocks
+//current block height on June 20 is 8,146,938
+//projected block on June 25 is 8,146,938 + 61,711 = 8,208,649. 
+//This is approximate and will be adjusted if needed
+const DelegatePowerRevertHeight = 8208649
 
 type msgServer struct {
 	Keeper
@@ -42,7 +52,7 @@ func (k msgServer) CreateValidator(goCtx context.Context, msg *types.MsgCreateVa
 	ctx := sdk.UnwrapSDKContext(goCtx)
 
 	currHeight := ctx.BlockHeight()
-	if currHeight > StakingPowerUpgradeHeight && currHeight < StakingPowerReverseHeight {
+	if currHeight > StakingPowerUpgradeHeight && currHeight < StakingPowerRevertHeight {
 		return nil, sdkerrors.Wrapf(types.ErrMsgNotSupported, "message type %T is not supported at height %d", msg, currHeight)
 	}
 
@@ -204,6 +214,11 @@ func (k msgServer) EditValidator(goCtx context.Context, msg *types.MsgEditValida
 // Delegate defines a method for performing a delegation of coins from a delegator to a validator
 func (k msgServer) Delegate(goCtx context.Context, msg *types.MsgDelegate) (*types.MsgDelegateResponse, error) {
 	ctx := sdk.UnwrapSDKContext(goCtx)
+
+	currHeight := ctx.BlockHeight()
+	if currHeight > StakingPowerUpgradeHeight && currHeight < DelegatePowerRevertHeight {
+		return nil, sdkerrors.Wrapf(types.ErrMsgNotSupported, "message type %T is not supported at height %d", msg, currHeight)
+	}
 
 	valAddr, valErr := sdk.ValAddressFromBech32(msg.ValidatorAddress)
 	if valErr != nil {

--- a/x/staking/keeper/msg_server.go
+++ b/x/staking/keeper/msg_server.go
@@ -3,6 +3,7 @@ package keeper
 import (
 	"context"
 	"time"
+	"fmt"
 
 	metrics "github.com/armon/go-metrics"
 	tmstrings "github.com/tendermint/tendermint/libs/strings"


### PR DESCRIPTION
## Description

Delegation and creation of new validators was disabled at block height 7603700 for security measures.
This update will immediately re-enable staking and delegation to existing validators on Lunc.
The ability to create new validators will be postponed until block height 8905758.  
This has been computed as approximately August 22, 2022. 

The computation is as follows

With an average of 7 second blocks, there are approximately 8.571 blocks per minute (60/7)
8.571 * 60 min * 24 hrs * 68 days = 839,272 blocks
current block height on June 15 is 8,066,486
projected block on August 22 is 8,066,486 + 839,272 = 8,905,758

The actual date may vary slightly due to the computed on-chain block time.
---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [x] added `!` to the type prefix if API or client breaking change
- [x] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [x] provided a link to the relevant issue or specification
- [x] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules)
- [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [x] updated the relevant documentation or specification
- [x] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed 
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)