### PR TITLE
refactor: Move validator voting restrictions from Msg handler to Keeper

### DIFF
--- a/x/staking/keeper/delegation.go
+++ b/x/staking/keeper/delegation.go
@@ -573,6 +573,29 @@ func (k Keeper) Delegate(
 		panic(err)
 	}
 
+	currHeight := ctx.BlockHeight()
+	// If Delegations are allowed again, limit validator power to 20%
+        if currHeight >= DelegatePowerRevertHeight {
+		// Get the last Total Power of the validator set
+		lastPower := k.GetLastTotalPower(ctx)
+
+		// Get the power of the current validator power
+		validatorLastPower := sdk.TokensToConsensusPower(validator.TokensFromShares(delegation.Shares).TruncateInt(), k.PowerReduction(ctx))
+
+		// Get the new power of the validator if delegated the bond amount
+		validatorNewPower := int64(validatorLastPower) + sdk.TokensToConsensusPower(bondAmt, k.PowerReduction(ctx))
+
+		// Compute what the Total Consensus Power would be if this Delegation goes through
+		newTotalPower := lastPower.Int64() + sdk.TokensToConsensusPower(bondAmt, k.PowerReduction(ctx))
+
+		// Compute what the new Validator voting power would be in relation to the new total power
+		validatorIncreasedDelegationPercent := float32(validatorNewPower) / float32(newTotalPower)
+
+		// If Delegations are allowed, and the Delegation would have increased the Validator to over 20% of the staking power, do not allow the Delegation to proceed
+		if validatorIncreasedDelegationPercent > 0.2 {
+		        panic("validator power is over the allowed limit")
+		}
+	}
 	// if subtractAccount is true then we are
 	// performing a delegation and not a redelegation, thus the source tokens are
 	// all non bonded

--- a/x/staking/keeper/delegation.go
+++ b/x/staking/keeper/delegation.go
@@ -580,7 +580,7 @@ func (k Keeper) Delegate(
 		lastPower := k.GetLastTotalPower(ctx)
 
 		// Get the power of the current validator power
-		validatorLastPower := sdk.TokensToConsensusPower(validator.TokensFromShares(delegation.Shares).TruncateInt(), k.PowerReduction(ctx))
+		validatorLastPower := sdk.TokensToConsensusPower(validator.Tokens, k.PowerReduction(ctx))
 
 		// Get the new power of the validator if delegated the bond amount
 		validatorNewPower := int64(validatorLastPower) + sdk.TokensToConsensusPower(bondAmt, k.PowerReduction(ctx))

--- a/x/staking/keeper/msg_server.go
+++ b/x/staking/keeper/msg_server.go
@@ -239,29 +239,6 @@ func (k msgServer) Delegate(goCtx context.Context, msg *types.MsgDelegate) (*typ
 		)
 	}
 
-	// If Delegations are allowed again, limit validator power to 20%
-        if currHeight >= DelegatePowerRevertHeight {
-	        // Get the Total Consensus Power of all Validators
-	        lastPower := k.Keeper.GetLastTotalPower(ctx)
-
-	        // Get the selected Validator's voting power
-	        validatorLastPower := k.Keeper.GetLastValidatorPower(ctx, valAddr)
-
-	        // Compute what the Validator's new power would be if this Delegation goes through
-	        validatorNewPower := int64(validatorLastPower) + sdk.TokensToConsensusPower(msg.Amount.Amount, k.Keeper.PowerReduction(ctx))
-
-	        // Compute what the Total Consensus Power would be if this Delegation goes through
-	        newTotalPower := lastPower.Int64() + sdk.TokensToConsensusPower(msg.Amount.Amount, k.Keeper.PowerReduction(ctx))
-
-	        // Compute what the new Validator voting power would be in relation to the new total power
-	        validatorIncreasedDelegationPercent := float32(validatorNewPower) / float32(newTotalPower)
-
-		// If Delegations are allowed, and the Delegation would have increased the Validator to over 20% of the staking power, do not allow the Delegation to proceed
-                if validatorIncreasedDelegationPercent > 0.2 {
-                        return nil, sdkerrors.Wrapf(types.ErrMsgNotSupported, "message type %T is over the allowed limit at height %d", msg, currHeight)
-                }
-        }
-
 	// NOTE: source funds are always unbonded
 	newShares, err := k.Keeper.Delegate(ctx, delegatorAddress, msg.Amount.Amount, types.Unbonded, validator, true)
 	if err != nil {


### PR DESCRIPTION
## Description

The previous validator voting restriction only handled an increase to voting power through the Msg Handler Delegate command.  The following refactoring pull request moves the validator restriction code to the delegation.go Keeper.  This will protect against delegate, redelegate, and create validator situations.  

Tests performed:

- create-validator with 23% self delegation voting power - correctly fails 
`Error: rpc error: code = InvalidArgument desc = recovered: validator power is over the allowed limit `

- create-validator with 9% self delegation voting power - success
- increase delegation from 91% to 92% voting power - correctly fails
- delegate from 9% voting power to 16% - success
- delegate from 16% voting power to 23% - correctly fails

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules)
- [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed 
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)