### PR TITLE
Features - healthcheck endpoint 

### DIFF
--- a/client/rpc/routes.go
+++ b/client/rpc/routes.go
@@ -10,6 +10,7 @@ import (
 func RegisterRoutes(clientCtx client.Context, r *mux.Router) {
 	r.HandleFunc("/node_info", NodeInfoRequestHandlerFn(clientCtx)).Methods("GET")
 	r.HandleFunc("/syncing", NodeSyncingRequestHandlerFn(clientCtx)).Methods("GET")
+	r.HandleFunc("/health", NodeHealthRequestHandlerFn(clientCtx)).Methods("GET")
 	r.HandleFunc("/blocks/latest", LatestBlockRequestHandlerFn(clientCtx)).Methods("GET")
 	r.HandleFunc("/blocks/{height}", BlockRequestHandlerFn(clientCtx)).Methods("GET")
 	r.HandleFunc("/validatorsets/latest", LatestValidatorSetRequestHandlerFn(clientCtx)).Methods("GET")

--- a/client/rpc/rpc_test.go
+++ b/client/rpc/rpc_test.go
@@ -56,6 +56,12 @@ func (s *IntegrationTestSuite) TestLatestBlocks() {
 	s.Require().NoError(err)
 }
 
+func (s *IntegrationTestSuite) TestHealth() {
+	val0 := s.network.Validators[0]
+	_, err := rest.GetRequest(fmt.Sprintf("%s/health", val0.APIAddress))
+	s.Require().NoError(err)
+}
+
 func TestIntegrationTestSuite(t *testing.T) {
 	suite.Run(t, new(IntegrationTestSuite))
 }

--- a/client/rpc/status.go
+++ b/client/rpc/status.go
@@ -131,6 +131,10 @@ func NodeSyncingRequestHandlerFn(clientCtx client.Context) http.HandlerFunc {
 	}
 }
 
+type HealthcheckResponse struct {
+	Health string `json:"health"`
+}
+
 // REST handler for node health check - aws recognizes only http status codes
 func NodeHealthRequestHandlerFn(clientCtx client.Context) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
@@ -141,7 +145,7 @@ func NodeHealthRequestHandlerFn(clientCtx client.Context) http.HandlerFunc {
 		if status.SyncInfo.CatchingUp {
 			rest.WriteErrorResponse(w, http.StatusServiceUnavailable, "NOK")
 		} else {
-			rest.PostProcessResponseBare(w, clientCtx, []byte("OK"))
+			rest.PostProcessResponseBare(w, clientCtx, HealthcheckResponse{Health: "OK"})
 		}
 	}
 }

--- a/client/rpc/status.go
+++ b/client/rpc/status.go
@@ -130,3 +130,18 @@ func NodeSyncingRequestHandlerFn(clientCtx client.Context) http.HandlerFunc {
 		rest.PostProcessResponseBare(w, clientCtx, SyncingResponse{Syncing: status.SyncInfo.CatchingUp})
 	}
 }
+
+// REST handler for node health check - aws recognizes only http status codes
+func NodeHealthRequestHandlerFn(clientCtx client.Context) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		status, err := getNodeStatus(clientCtx)
+		if rest.CheckInternalServerError(w, err) {
+			return
+		}
+		if status.SyncInfo.CatchingUp {
+			rest.WriteErrorResponse(w, http.StatusServiceUnavailable, "NOK")
+		} else {
+			rest.PostProcessResponseBare(w, clientCtx, []byte("OK"))
+		}
+	}
+}


### PR DESCRIPTION
## Description

This PR implements healthcheck endpoint (/health) that returns non-200 HTTP code in case the syncing is still in progress. This feature is needed because [Healtchecks for target groups](https://docs.aws.amazon.com/elasticloadbalancing/latest/network/target-group-health-checks.html)  currently do not implement matching on response content. 

The /syncing endpoint returns 200 in both cases and this creates issues while the node is syncing, as it is marked as 'healthy' with traffic being routed to it.


<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules)
- [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed 
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)