### PR TITLE
feat: expose module account setter

### DIFF
--- a/x/auth/keeper/keeper.go
+++ b/x/auth/keeper/keeper.go
@@ -216,6 +216,21 @@ func (ak AccountKeeper) GetModuleAccountAndPermissions(ctx sdk.Context, moduleNa
 	return maccI, perms
 }
 
+// SetModuleAccountAndPermissions the module account from the auth account store and its
+// registered permissions
+func (ak AccountKeeper) SetModuleAccountAndPermissions(ctx sdk.Context, moduleName string, perms ...string) types.ModuleAccountI {
+	// create a new empty module account
+	macc := types.NewEmptyModuleAccount(moduleName, perms...)
+	// set the account number
+	maccI := (ak.NewAccount(ctx, macc)).(types.ModuleAccountI)
+	// Add the account to the store
+	ak.SetModuleAccount(ctx, maccI)
+	// Add the permissions for the module account
+	ak.permAddrs[moduleName] = types.NewPermissionsForAddress(maccI.GetName(), perms)
+
+	return maccI
+}
+
 // GetModuleAccount gets the module account from the auth account store, if the account does not
 // exist in the AccountKeeper, then it is created.
 func (ak AccountKeeper) GetModuleAccount(ctx sdk.Context, moduleName string) types.ModuleAccountI {


### PR DESCRIPTION
This is needed to be able to overwrite the `builder` external owned account with a module account