### PR TITLE
fix: query paramssubspace when params not available

### DIFF
--- a/x/distribution/keeper/keeper.go
+++ b/x/distribution/keeper/keeper.go
@@ -9,6 +9,7 @@ import (
 	storetypes "github.com/cosmos/cosmos-sdk/store/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	"github.com/cosmos/cosmos-sdk/x/distribution/exported"
 	"github.com/cosmos/cosmos-sdk/x/distribution/types"
 )
 
@@ -21,20 +22,24 @@ type Keeper struct {
 	stakingKeeper types.StakingKeeper
 	// the address capable of executing a MsgUpdateParams message. Typically, this
 	// should be the x/gov module account.
-	authority string
-
+	authority        string
 	feeCollectorName string // name of the FeeCollector ModuleAccount
+	legacySubspace   exported.Subspace
 }
 
 // NewKeeper creates a new distribution Keeper instance
 func NewKeeper(
 	cdc codec.BinaryCodec, key storetypes.StoreKey,
 	ak types.AccountKeeper, bk types.BankKeeper, sk types.StakingKeeper,
-	feeCollectorName string, authority string,
+	feeCollectorName string, authority string, legacySubspaces ...exported.Subspace,
 ) Keeper {
 	// ensure distribution module account is set
 	if addr := ak.GetModuleAddress(types.ModuleName); addr == nil {
 		panic(fmt.Sprintf("%s module account has not been set", types.ModuleName))
+	}
+
+	if len(legacySubspaces) == 0 {
+		panic("legacySubspace must be provided for x/distribution")
 	}
 
 	return Keeper{
@@ -45,6 +50,7 @@ func NewKeeper(
 		stakingKeeper:    sk,
 		feeCollectorName: feeCollectorName,
 		authority:        authority,
+		legacySubspace:   legacySubspaces[0],
 	}
 }
 

--- a/x/distribution/keeper/params.go
+++ b/x/distribution/keeper/params.go
@@ -12,6 +12,7 @@ func (k Keeper) GetParams(clientCtx sdk.Context) (params types.Params) {
 	store := clientCtx.KVStore(k.storeKey)
 	bz := store.Get(types.ParamsKey)
 	if bz == nil {
+		k.legacySubspace.GetParamSet(clientCtx, &params)
 		return params
 	}
 

--- a/x/distribution/module.go
+++ b/x/distribution/module.go
@@ -223,7 +223,7 @@ type DistrInputs struct {
 	StakingKeeper types.StakingKeeper
 
 	// LegacySubspace is used solely for migration of x/params managed parameters
-	LegacySubspace exported.Subspace `optional:"true"`
+	LegacySubspace exported.Subspace
 }
 
 type DistrOutputs struct {

--- a/x/distribution/module.go
+++ b/x/distribution/module.go
@@ -254,6 +254,7 @@ func ProvideModule(in DistrInputs) DistrOutputs {
 		in.StakingKeeper,
 		feeCollectorName,
 		authority.String(),
+		in.LegacySubspace,
 	)
 
 	m := NewAppModule(in.Cdc, k, in.AccountKeeper, in.BankKeeper, in.StakingKeeper, in.LegacySubspace)


### PR DESCRIPTION
As explained here https://github.com/cosmos/cosmos-sdk/issues/17597 CosmosSDK will point to a new memory position to recover the module params. But older versions of the state does not have this information at the same memory position. To fix it we can try querying the legacySubspace.